### PR TITLE
feat: to tackle proxies, reads xforwardedfor first then remoteaddr

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -8,3 +8,4 @@ import: github.com/traefik-plugins/traefikgeoip2
 
 testData:
   dbPath: 'GeoLite2-Country.mmdb'
+  preferXForwardedForHeader: false


### PR DESCRIPTION
This is to make sure it reads the clientip even though a request can travel to multiple proxies before reaching destination.